### PR TITLE
Add sdk (Java/JDK installer), clarify purpose in README

### DIFF
--- a/1.setup.sh
+++ b/1.setup.sh
@@ -106,7 +106,7 @@ idem_cmd nvm
 
 function init_sdk() { # in fact, the JDK (sdk is a version manager for Java, much like nvm)
   curl -s "https://get.sdkman.io" | bash
-  source "/home/erik/.sdkman/bin/sdkman-init.sh"
+  source ~/.sdkman/bin/sdkman-init.sh
   sdk install java 21.0.1-tem
 }
 idem_cmd sdk

--- a/1.setup.sh
+++ b/1.setup.sh
@@ -104,6 +104,13 @@ function init_nvm() {
 }
 idem_cmd nvm
 
+function init_sdk() { # in fact, the JDK (sdk is a version manager for Java, much like nvm)
+  curl -s "https://get.sdkman.io" | bash
+  source "/home/erik/.sdkman/bin/sdkman-init.sh"
+  sdk install java 21.0.1-tem
+}
+idem_cmd sdk
+
 idem "command -v code" "sudo snap install --classic code"
 
 idem "command -v convert" "sudo apt install imagemagick"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Welcome!
 
-This repository is intended to help get you set up for the first time or reinitialize a clean machine.  Of course you are welcomed to preview the commands that you are asked to run but the pooint of this repo is to give everyone a consistent agreement on shared setup and configuration so that our shared scripts run properly.
+This repository is intended to help get you set up for the first time or reinitialize a clean machine.  This is intended to set up a new Ubuntu machine.  Of course you are welcomed to preview the commands that you are asked to run but the point of this repo is to give everyone a consistent agreement on shared setup and configuration so that our shared scripts run properly.
 
 Thank you for your attention, please help improve this, and enjoy!
 


### PR DESCRIPTION
I am adding this to facilitate DynamoDB Local usage during unit testing.  I would prefer a fully in-memory option but that wouldn't be very sustainable for AWS or a independent maintainer to produce.